### PR TITLE
✨ Fix UI issues and improve liquid glass styling

### DIFF
--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -4076,7 +4076,7 @@ StWidget.focused .app-grid-running-dot {
   border-radius: 20px;
   padding: 4px;
   margin: 3px;
-  background-color: rgba(255, 255, 255, 0.15);
+background-color: rgba(50, 50, 50, 0.89);
   border-radius: 20px;
   box-shadow: inset 0 0 4px 0.1px rgba(255, 255, 255, 0.4);
   color: #afafaf;
@@ -4085,12 +4085,12 @@ StWidget.focused .app-grid-running-dot {
 .popup-menu .message:hover,
 .popup-menu .message:focus {
   color: #dedede;
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(75, 75, 75, 0.92);
 }
 
 .popup-menu .message:active {
   color: #dedede;
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: rgba(85, 85, 85, 0.92);
   box-shadow: none !important;
 }
 

--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -4574,6 +4574,10 @@ background-color: rgba(50, 50, 50, 0.89);
   spacing: 8px;
 }
 
+.quick-toggle.power-item .quick-toggle-title {
+  padding-right: 10px;
+}
+
 .quick-toggle.button {
   padding: 0;
 }

--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -2758,7 +2758,7 @@ StEntry StLabel.hint-text {
 .popup-menu-content {
   padding: 4px;
   margin: 4px 12px 17px 12px;
-  background-color: rgba(0, 0, 0, 0.92);
+  background-color: rgba(0, 0, 0, 0.72);
   border-radius: 30px;
   border: solid rgba(0, 0, 0, 0);
   border-width: 1px;

--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -4711,9 +4711,9 @@ background-color: rgba(50, 50, 50, 0.89);
 
 .quick-slider {
   background-color: rgba(255, 255, 255, 0.15);
-  border-radius: 24px;
+  border-radius: 34px;
   box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.35) !important;
-  padding: 1.636em 0.818em;
+  padding: 1.636em 1.5em 1.636em 0.818em;
   color: white;
 }
 
@@ -4757,6 +4757,7 @@ background-color: rgba(50, 50, 50, 0.89);
 .quick-slider .slider-bin {
   min-height: 16px;
   padding: 4px;
+  padding-right: 16px;
   border-radius: 9999px;
 }
 
@@ -4765,12 +4766,10 @@ background-color: rgba(50, 50, 50, 0.89);
 }
 
 .quick-toggle-menu {
-  background-color: rgba(36, 36, 36, 0.92) !important;
-  border-radius: 20px;
-  padding: 12px;
-  margin: 8px 28px 0;
-  border: none !important;
-  box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.18);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 30px;
+  box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.35) !important;
+  color: white;
 }
 
 .quick-toggle-menu .popup-menu-item {

--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -4106,12 +4106,12 @@ background-color: rgba(50, 50, 50, 0.89);
 
 .message:second-in-stack {
   background-color: #404040;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  box-shadow: inset 0 0 4px 0.1px rgba(255, 255, 255, 0.3);
 }
 
 .message:lower-in-stack {
   background-color: #363636;
-  box-shadow: none;
+  box-shadow: inset 0 0 4px 0.1px rgba(255, 255, 255, 0.25);
   border-color: transparent;
 }
 

--- a/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Dark/gnome-shell/gnome-shell.css
@@ -4302,13 +4302,17 @@ background-color: rgba(50, 50, 50, 0.89);
   min-height: 64px;
   width: 34em;
   border-radius: 14px;
-  margin: 8px;
-  padding: 4px;
+  margin: 10px;
+  padding: 10px;
   color: #dedede;
-  background-color: rgba(36, 36, 36, 0.92);
-  border: 1px solid rgba(0, 0, 0, 0.75);
+  background-color: rgba(40, 40, 40, 0.7);
+  border: none;
   text-shadow: none;
-  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 3px 0.1px rgba(255, 255, 255, 0.3);
+}
+
+.notification-banner .message-close-button {
+  box-shadow: inset 0 0 3px 0.1px rgba(255, 255, 255, 0.3) !important;
 }
 
 .notification-buttons-bin {
@@ -4319,11 +4323,11 @@ background-color: rgba(50, 50, 50, 0.89);
 .notification-button {
   min-height: 32px;
   padding: 0 8px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgba(255, 255, 255, 0.1);
   color: #afafaf;
   font-weight: 500;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: 18px;
 }
 
 .notification-button:focus {

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk-dark.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk-dark.css
@@ -66,8 +66,6 @@
   --overview-bg-color: #28282c;
   --overview-fg-color: #ffffff;
 }
-@import '../gtk-3.0/libadwaita.css';
-@import '../gtk-3.0/libadwaita-tweaks.css';
 
 * {
   border-radius: 20px;
@@ -135,7 +133,6 @@ headerbar button:not(.suggested-action):not(.destructive-action),
 button.close,
 button.circular {
   border-radius: 9999px;
-  -gtk-outline-radius: 9999px;
 }
 
 headerbar,

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -855,6 +855,17 @@ box.bottom.floating-bar {
     inset -2px -2px 2px -2.8px rgba(255, 255, 255, 0.8);
 }
 
+toastoverlay toast {
+  background-color: rgba(0, 0, 0, 0.93);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.2),
+    rgba(255, 255, 255, 0.06)
+  );
+  box-shadow: inset 2px 2px 4px -2.8px rgba(255, 255, 255, 0.6),
+    inset -2px -2px 4px -2.8px rgba(255, 255, 255, 0.6);
+}
+
 /*
  row.activatable.entry {
   background-color: rgba(0, 0, 0, 0);

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -619,23 +619,23 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list > row {
+list.boxed-list row {
   border-radius: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-list.boxed-list > row:first-child {
+list.boxed-list row:first-child {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
 }
 
-list.boxed-list > row:last-child {
+list.boxed-list row:last-child {
   border-bottom-left-radius: 16px;
   border-bottom-right-radius: 16px;
   border-bottom: none;
 }
 
-list.boxed-list > row:only-child {
+list.boxed-list row:only-child {
   border-radius: 16px;
   border-bottom: none;
 }

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -742,7 +742,7 @@ window#NautilusFileChooser > revealer.bottom-bar {
   margin-left: 10px;
 }
 
-#NautilusPathBar {
+#NautilusPathBar, .nautilus-pathbar {
   background-color: rgba(0, 0, 0, 0);
   background-image: linear-gradient(
     to bottom,

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -619,23 +619,27 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list row {
+list.boxed-list row, 
+list.content row {
   border-radius: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-list.boxed-list row:first-child {
+list.boxed-list row:first-child, 
+list.content row:first-child {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
 }
 
-list.boxed-list row:last-child {
+list.boxed-list row:last-child, 
+list.content row:last-child {
   border-bottom-left-radius: 16px;
   border-bottom-right-radius: 16px;
   border-bottom: none;
 }
 
-list.boxed-list row:only-child {
+list.boxed-list row:only-child, 
+list.content row:only-child {
   border-radius: 16px;
   border-bottom: none;
 }
@@ -650,6 +654,20 @@ widget.end.sidebar-pane > widget,
 widget.end.sidebar-pane > widget > preferencespage {
   margin-top: -14px;
   margin-bottom: -14px;
+}
+
+widget.sidebar-pane preferencespage > scrolledwindow > viewport {
+  border-radius: 30px;
+}
+
+widget.sidebar-pane preferencespage > scrolledwindow {
+  margin-top: 14px;
+  margin-bottom: 14px;
+}
+
+floating-sheet sheet.background preferencespage > scrolledwindow {
+  margin: 25px;
+  margin-bottom: 35px;
 }
 
 widget.end.sidebar-pane {

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -66,8 +66,6 @@
   --overview-bg-color: #28282c;
   --overview-fg-color: #ffffff;
 }
-@import '../gtk-3.0/libadwaita.css';
-@import '../gtk-3.0/libadwaita-tweaks.css';
 
 * {
   border-radius: 20px;
@@ -140,7 +138,6 @@ headerbar button:not(.suggested-action):not(.destructive-action),
 button.close,
 button.circular {
   border-radius: 9999px;
-  -gtk-outline-radius: 9999px;
 }
 
 button.image-button.toggle {
@@ -585,8 +582,6 @@ windowcontrols > button > image {
 
 windowcontrols {
   margin-right: -6px;
-  max-width: 12px;
-  max-height: 12px;
 }
 
 /*********************
@@ -985,7 +980,7 @@ stack.background {
 
 box.split-row.vertical {
   border-radius: 0;
-  border-bottom-color: rgba(0, 0, 0, 0, 0.2);
+  border-bottom-color: rgba(0, 0, 0, 0.2);
 }
 
 leaflet.unfolded > separator.horizontal {

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -920,6 +920,9 @@ popover > contents {
     rgba(255, 255, 255, 0.1),
     rgba(255, 255, 255, 0.03)
   );
+  box-shadow: inset 2px 2px 4px -2.8px rgba(255, 255, 255, 0.6),
+    inset -2px -2px 4px -2.8px rgba(255, 255, 255, 0.6);
+  border-radius: 16px;
 }
 
 popover > arrow {

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -797,6 +797,27 @@ window#NautilusAppChooser > scrolledwindow.background {
   border: none;
 }
 
+dialog.floating.nautilus-app-chooser listview.view {
+  padding: 4px;
+  
+}
+
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-bottom.undershoot-top widget.toolbar {
+  padding-top: 6px;
+  padding-bottom: 0px;
+  
+}
+
+dialog.floating.nautilus-app-chooser listview.view > header {
+  padding-top: 10px;
+  
+}
+
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-bottom.undershoot-top,
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-top {
+  padding: 10px;
+}
+
 list.background {
   background-color: rgba(0, 0, 0, 0);
   background-image: linear-gradient(

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -1179,3 +1179,15 @@ overlay-split-vew.window-chatpage
   > button.image-button.toggle {
   margin-right: -4px;
 }
+
+/*********************
+ * Disk Usage Analyzer *
+ *********************/
+
+overlay-split-view box columnview.view,
+overlay-split-view scrolledwindow columnview.view {
+  background-color: rgba(0, 0, 0, 0);
+  padding-top: 2px;
+  padding-left: 6px;
+  padding-right: 6px;
+}

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -656,11 +656,13 @@ widget.end.sidebar-pane > widget > preferencespage {
   margin-bottom: -14px;
 }
 
-widget.sidebar-pane preferencespage > scrolledwindow > viewport {
+widget.sidebar-pane preferencespage > scrolledwindow > viewport,
+overlay-split-view widget > scrolledwindow > viewport {
   border-radius: 30px;
 }
 
-widget.sidebar-pane preferencespage > scrolledwindow {
+widget.sidebar-pane preferencespage > scrolledwindow,
+overlay-split-view widget > scrolledwindow {
   margin-top: 14px;
   margin-bottom: 14px;
 }

--- a/gtk/Tahoe-Dark/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Dark/gtk-4.0/gtk.css
@@ -624,12 +624,25 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list > row.property,
-list.boxed-list > row.activatable.combo,
-list.boxed-list > row.activatable {
-  border-bottom-color: rgba(0, 0, 0, 0.2);
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+list.boxed-list > row {
+  border-radius: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+list.boxed-list > row:first-child {
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+list.boxed-list > row:last-child {
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
+  border-bottom: none;
+}
+
+list.boxed-list > row:only-child {
+  border-radius: 16px;
+  border-bottom: none;
 }
 
 widget.end.sidebar-pane,

--- a/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
@@ -4575,6 +4575,10 @@ StWidget.focused .app-grid-running-dot {
   spacing: 8px;
 }
 
+.quick-toggle.power-item .quick-toggle-title {
+  padding-right: 10px;
+}
+
 .quick-toggle.button {
   padding: 0;
 }

--- a/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
@@ -2759,7 +2759,7 @@ StEntry StLabel.hint-text {
 .popup-menu-content {
   padding: 4px;
   margin: 4px 12px 17px 12px;
-  background-color: rgba(255, 255, 255, 0.82);
+  background-color: rgba(255, 255, 255, 0.72);
   border-radius: 30px;
   border: solid rgba(0, 0, 0, 0);
   border-width: 1px;

--- a/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
@@ -4303,10 +4303,10 @@ StWidget.focused .app-grid-running-dot {
   min-height: 64px;
   width: 34em;
   border-radius: 14px;
-  margin: 8px;
-  padding: 4px;
+  margin: 10px;
+  padding: 10px;
   color: #242424;
-  background-color: rgba(245, 245, 245, 0.92);
+  background-color: rgba(245, 245, 245, 0.82);
   border: 1px solid transparent;
   text-shadow: none;
   box-shadow: 0 3px 5px rgba(0, 0, 0, 0.15);
@@ -4324,7 +4324,7 @@ StWidget.focused .app-grid-running-dot {
   color: #424242;
   font-weight: 500;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: 18px;
 }
 
 .notification-button:focus {

--- a/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
+++ b/gtk/Tahoe-Light/gnome-shell/gnome-shell.css
@@ -4712,9 +4712,9 @@ StWidget.focused .app-grid-running-dot {
 
 .quick-slider {
   background-color: rgba(255, 255, 255, 0.15);
-  border-radius: 24px;
+  border-radius: 34px;
   box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.35) !important;
-  padding: 1.636em 0.818em;
+  padding: 1.636em 1.5em 1.636em 0.818em;
   color: white;
 }
 
@@ -4758,6 +4758,7 @@ StWidget.focused .app-grid-running-dot {
 .quick-slider .slider-bin {
   min-height: 16px;
   padding: 4px;
+  padding-right: 16px;
   border-radius: 9999px;
 }
 
@@ -4766,12 +4767,10 @@ StWidget.focused .app-grid-running-dot {
 }
 
 .quick-toggle-menu {
-  background-color: rgba(245, 245, 245, 0.92) !important;
-  border-radius: 22px;
-  padding: 12px;
-  margin: 8px 28px 0;
-  border: none !important;
-  box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.18);
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 30px;
+  box-shadow: inset 0 0 4px rgba(255, 255, 255, 0.35) !important;
+  color: white;
 }
 
 .quick-toggle-menu .popup-menu-item {

--- a/gtk/Tahoe-Light/gtk-4.0/gtk-dark.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk-dark.css
@@ -66,8 +66,6 @@
   --overview-bg-color: #28282c;
   --overview-fg-color: #ffffff;
 }
-@import '../gtk-3.0/libadwaita.css';
-@import '../gtk-3.0/libadwaita-tweaks.css';
 
 * {
   border-radius: 20px;
@@ -135,7 +133,6 @@ headerbar button:not(.suggested-action):not(.destructive-action),
 button.close,
 button.circular {
   border-radius: 9999px;
-  -gtk-outline-radius: 9999px;
 }
 
 headerbar,

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -616,10 +616,25 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list > row.property,
-list.boxed-list > row.activatable.combo,
-list.boxed-list > row.activatable {
-  border-bottom-color: rgba(255, 255, 255, 0);
+list.boxed-list > row {
+  border-radius: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+list.boxed-list > row:first-child {
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+list.boxed-list > row:last-child {
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
+  border-bottom: none;
+}
+
+list.boxed-list > row:only-child {
+  border-radius: 16px;
+  border-bottom: none;
 }
 
 widget.end.sidebar-pane,

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -846,6 +846,18 @@ box.bottom.floating-bar {
     inset -2px -2px 2px -2.8px rgb(255, 255, 255);
 }
 
+toastoverlay toast {
+  background-color: rgba(255, 255, 255, 0.86);
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.5),
+    rgba(255, 255, 255, 0.43)
+  );
+  box-shadow: inset 2px 2px 4px -2.8px rgb(255, 255, 255),
+    inset -2px -2px 4px -2.8px rgb(255, 255, 255);
+  color: rgba(30, 30, 30, 0.8);
+}
+
 /*
  row.activatable.entry {
   background-color: rgba(255, 255, 255, 0);

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -919,6 +919,9 @@ popover > contents {
     rgba(255, 255, 255, 0.5),
     rgba(255, 255, 255, 0.43)
   );
+  box-shadow: inset 2px 2px 4px -2.8px rgb(255, 255, 255),
+    inset -2px -2px 4px -2.8px rgb(255, 255, 255);
+  border-radius: 16px;
 }
 
 popover > arrow {

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -610,23 +610,27 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list row {
+list.boxed-list row, 
+list.content row {
   border-radius: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-list.boxed-list row:first-child {
+list.boxed-list row:first-child, 
+list.content row:first-child {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
 }
 
-list.boxed-list row:last-child {
+list.boxed-list row:last-child, 
+list.content row:last-child {
   border-bottom-left-radius: 16px;
   border-bottom-right-radius: 16px;
   border-bottom: none;
 }
 
-list.boxed-list row:only-child {
+list.boxed-list row:only-child, 
+list.content row:only-child {
   border-radius: 16px;
   border-bottom: none;
 }
@@ -641,6 +645,20 @@ widget.end.sidebar-pane > widget,
 widget.end.sidebar-pane > widget > preferencespage {
   margin-top: -14px;
   margin-bottom: -14px;
+}
+
+widget.sidebar-pane preferencespage > scrolledwindow > viewport {
+  border-radius: 30px;
+}
+
+widget.sidebar-pane preferencespage > scrolledwindow {
+  margin-top: 14px;
+  margin-bottom: 14px;
+}
+
+floating-sheet sheet.background preferencespage > scrolledwindow {
+  margin: 25px;
+  margin-bottom: 35px;
 }
 
 widget.end.sidebar-pane {

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -610,23 +610,23 @@ separator.vertical {
   opacity: 0;
 }
 
-list.boxed-list > row {
+list.boxed-list row {
   border-radius: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
-list.boxed-list > row:first-child {
+list.boxed-list row:first-child {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
 }
 
-list.boxed-list > row:last-child {
+list.boxed-list row:last-child {
   border-bottom-left-radius: 16px;
   border-bottom-right-radius: 16px;
   border-bottom: none;
 }
 
-list.boxed-list > row:only-child {
+list.boxed-list row:only-child {
   border-radius: 16px;
   border-bottom: none;
 }

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -788,6 +788,27 @@ window#NautilusAppChooser > scrolledwindow.background {
   border: none;
 }
 
+dialog.floating.nautilus-app-chooser listview.view {
+  padding: 4px;
+  
+}
+
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-bottom.undershoot-top widget.toolbar {
+  padding-top: 6px;
+  padding-bottom: 0px;
+  
+}
+
+dialog.floating.nautilus-app-chooser listview.view > header {
+  padding-top: 10px;
+  
+}
+
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-bottom.undershoot-top,
+dialog.floating.nautilus-app-chooser toolbarview.undershoot-top {
+  padding: 10px;
+}
+
 list.background {
   background-color: rgba(255, 255, 255, 0);
   background-image: linear-gradient(

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -733,7 +733,7 @@ window#NautilusFileChooser > revealer.bottom-bar {
   margin-left: 10px;
 }
 
-#NautilusPathBar {
+#NautilusPathBar, .nautilus-pathbar {
   background-color: rgba(255, 255, 255, 0);
   background-image: linear-gradient(
     to bottom,

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -647,11 +647,13 @@ widget.end.sidebar-pane > widget > preferencespage {
   margin-bottom: -14px;
 }
 
-widget.sidebar-pane preferencespage > scrolledwindow > viewport {
+widget.sidebar-pane preferencespage > scrolledwindow > viewport,
+overlay-split-view widget > scrolledwindow > viewport {
   border-radius: 30px;
 }
 
-widget.sidebar-pane preferencespage > scrolledwindow {
+widget.sidebar-pane preferencespage > scrolledwindow,
+overlay-split-view widget > scrolledwindow {
   margin-top: 14px;
   margin-bottom: 14px;
 }

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -66,9 +66,6 @@
   --overview-fg-color: rgb(0 0 6 / 80%);
 }
 
-@import '../gtk-3.0/libadwaita.css';
-@import '../gtk-3.0/libadwaita-tweaks.css';
-
 * {
   border-radius: 20px;
 }
@@ -140,7 +137,6 @@ headerbar button:not(.suggested-action):not(.destructive-action),
 button.close,
 button.circular {
   border-radius: 9999px;
-  -gtk-outline-radius: 9999px;
 }
 
 button.image-button.toggle {
@@ -577,8 +573,6 @@ windowcontrols > button > image {
 
 windowcontrols {
   margin-right: -6px;
-  max-width: 12px;
-  max-height: 12px;
 }
 
 /*********************

--- a/gtk/Tahoe-Light/gtk-4.0/gtk.css
+++ b/gtk/Tahoe-Light/gtk-4.0/gtk.css
@@ -1182,3 +1182,15 @@ overlay-split-vew.window-chatpage
   > button.image-button.toggle {
   margin-right: -4px;
 }
+
+/*********************
+ * Disk Usage Analyzer *
+ *********************/
+
+overlay-split-view box columnview.view,
+overlay-split-view scrolledwindow columnview.view {
+  background-color: rgba(0, 0, 0, 0);
+  padding-top: 2px;
+  padding-left: 6px;
+  padding-right: 6px;
+}


### PR DESCRIPTION
Fixes several UI issues and improves liquid glass styling consistency across GNOME apps and GNOME Shell. Tested on GNOME 50.

## What Changed

**General UI**

- Fix issue where highlighted group list rows show non-rounded bottom corners. Also resolves some activated text boxes having non rounded bottom corners
- Added Liquid Glass effect on popover menus to be more consistent and match closer to MacOS Tahoe.

Before | After
--- | ---
<img width="592" height="246" alt="ScreencastFrom2026-07-0522-42-21-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/fd89d036-ac39-46ba-8f8d-fa0c3bd01d31" /> | <img width="592" height="246" alt="after" src="https://github.com/user-attachments/assets/f621090c-1fad-4ab1-978d-f8dd96f4b0f4" />
<img width="281" height="419" alt="Screenshot From 2026-07-05 22-51-12" src="https://github.com/user-attachments/assets/7e58e4b4-0a62-4531-9543-c67598110f1f" /> | <img width="281" height="419" alt="Screenshot From 2026-07-05 22-51-43" src="https://github.com/user-attachments/assets/6e613960-b28b-43e8-b79b-c260d3697cca" />
<img width="460" height="234" alt="Screenshot From 2026-07-06 00-23-32" src="https://github.com/user-attachments/assets/9a5b5767-1707-4dd2-80fe-52811997a10a" /> | <img width="467" height="285" alt="Screenshot From 2026-07-06 00-23-57" src="https://github.com/user-attachments/assets/81d6cb50-ec04-42f2-a29b-9c7d748ac52c" />

**System Menu**

- Adds liquid glass styling to the quick toggle menu like the wifi menu to better match MacOS Tahoe's Control Center and theme.
- Rounded the corners a little more on the sliders to match closer to MacOS Tahoe's and adjusted the right padding of the sliders to be more centered
- Centered battery percentage

Before | After
--- | ---
<img width="434" height="664" alt="Screenshot From 2026-07-05 22-57-40" src="https://github.com/user-attachments/assets/1d54032c-814c-4ef9-afa9-f5523bc81c0f" /> | <img width="434" height="664" alt="Screenshot From 2026-07-05 22-57-57" src="https://github.com/user-attachments/assets/4c310b44-2341-4a9b-8abf-91b6df7845d8" />
<img width="437" height="886" alt="Screenshot From 2026-07-05 22-58-19" src="https://github.com/user-attachments/assets/91e329aa-e5bd-459c-b0fa-08388534b266" /> | <img width="437" height="886" alt="Screenshot From 2026-07-05 22-58-07" src="https://github.com/user-attachments/assets/97e39796-b334-440a-be72-6b44abfb1c62" />


**Notifications / Time & Date menu**

- Fixes the unthemed notification pop up banner
- Fixes stacked notifications being unreadable because the top notification is too transparent
- Slightly lowered opacity of popup menus by 20% to make blur effect a little more clearer and to be more consistent with how transparent other apps are.
- Added Liquid glass effect on last of stack notification, and increased the strength of the liquid glass effect on the second in stack of stacked notifications to make them more clearer

Before | After
--- | ---
<img width="733" height="383" alt="Screenshot From 2026-07-04 01-32-38" src="https://github.com/user-attachments/assets/582dd293-0abb-453e-a480-5123dafd81c5" />  | <img width="733" height="383" alt="Screenshot From 2026-07-04 01-36-11" src="https://github.com/user-attachments/assets/59a12880-859b-44a4-9deb-4254bfd88ab3" />
<img width="744" height="566" alt="Screenshot From 2026-07-05 23-18-07" src="https://github.com/user-attachments/assets/15f7d0a6-7612-4fb7-a228-8c793f44dfb1" /> | <img width="744" height="566" alt="Screenshot From 2026-07-05 23-22-09" src="https://github.com/user-attachments/assets/031fd346-d080-4ba7-a587-f452ac9849a6" />
<img width="533" height="178" alt="Screenshot From 2026-07-05 23-54-24" src="https://github.com/user-attachments/assets/987b2a89-8f01-4b7a-9616-52735eb24101" /> | <img width="533" height="178" alt="Screenshot From 2026-07-05 23-53-26" src="https://github.com/user-attachments/assets/ac724c79-e6c9-4e1a-9758-9d94aeeb5153" />

**Nautilus**

- Styled Toast Notifications
- Fixed Pathbar not having Liquid Glass effect due to #NautilusPathBar no longer being used in Nautilus
- Fixed padding in "Open with..." because the contents were too close to the edges.

Before | After
--- | ---
<img width="957" height="645" alt="Screenshot From 2026-07-05 23-31-00" src="https://github.com/user-attachments/assets/55d76cb3-6802-4623-97c8-569098e35d37" /> | <img width="957" height="645" alt="Screenshot From 2026-07-05 23-29-59" src="https://github.com/user-attachments/assets/93ab4388-d5a8-4166-a729-993bab9a4f36" />
<img width="429" height="581" alt="Screenshot From 2026-07-05 23-31-30" src="https://github.com/user-attachments/assets/176d129e-4eb8-4e15-a5c4-a8212de22e5a" /> | <img width="424" height="587" alt="Screenshot From 2026-07-05 23-32-23" src="https://github.com/user-attachments/assets/31cf3b3d-744c-4130-8852-80c95d88df0f" />



**Disk Usage Analyzer**

- Fixes Disk Usage Analyzer side panel by removing a dark gray box appearing behind the scrollable left panel and adjusted padding to prevent content from being too close to the edge.

Before | After
--- | ---
<img width="1056" height="640" alt="Screenshot From 2026-07-05 21-45-57" src="https://github.com/user-attachments/assets/b20e8395-7688-43a3-b5d1-c79682a18de7" /> | <img width="1056" height="640" alt="Screenshot From 2026-07-05 21-45-07" src="https://github.com/user-attachments/assets/51753344-f20f-4932-b760-d487a95dbc8a" />


**Image Viewer / Text Editor Document properties layout**

- Fixes content clipping when scrolling in the document properties sidebar
- Fixes item list riding outside the frame in the Document Type floating sheet in text editor.

Before | After
--- | ---
<img width="615" height="300" alt="Screenshot From 2026-07-06 00-06-53" src="https://github.com/user-attachments/assets/aafdc43c-ece2-47e1-bf29-2634974a0721" /> |<img width="615" height="300" alt="Screenshot From 2026-07-06 00-07-33" src="https://github.com/user-attachments/assets/da4ce015-9f23-4c00-9971-2a94b822f08d" />
<img width="928" height="819" alt="Screenshot From 2026-07-06 00-09-58" src="https://github.com/user-attachments/assets/1e2fcac6-7587-44ac-bbfc-fc692124957f" /> | <img width="928" height="819" alt="Screenshot From 2026-07-06 00-09-35" src="https://github.com/user-attachments/assets/bb56c09e-3d2d-45e9-8667-b4e5eda3089a" />

**Misc**

- Resolves GTK warnings that appear in #96

## Issues tackled

- Closes #60 
- Closes #96 
- Partially addresses #66 

## Notes

- The `@import` removal in "Cleaned up GTK Warnings" removes references to non-existent GTK 3.0 files. These imports generated warnings on app initialization, and manually placing the referenced files actually breaks the theme, making removal the correct fix.